### PR TITLE
Set explicit polyjuice bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "mocha": "^2.2.5"
   },
   "bin": {
-    "polyjuice": "./lib/bin"
+    "polyjuice": "./lib/bin.js"
   }
 }


### PR DESCRIPTION
I kept getting this error when trying to install locally or globally. I finally just git cloned the repo and did `npm link` and this seemed to work (OS X Yosemite):

```
➜  poly  npm-next i polyjuice
npm ERR! Darwin 14.4.0
npm ERR! argv "node" "/Users/pdehaan/.npm-packages/lib/node_modules/npm-next/node_modules/npm/cli.js" "i" "polyjuice"
npm ERR! node v0.10.35
npm ERR! npm  v2.12.0
npm ERR! path /Users/pdehaan/dev/tmp/del/poly/node_modules/polyjuice/lib/bin
npm ERR! code ENOENT
npm ERR! errno 34

npm ERR! enoent ENOENT, chmod '/Users/pdehaan/dev/tmp/del/poly/node_modules/polyjuice/lib/bin'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/pdehaan/dev/tmp/del/poly/npm-debug.log
```