### PR TITLE
Fixes empty object output if you don't specify any CLI arguments

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -28,6 +28,11 @@ if (src.options.jshint && src.options.jscs) {
   output = polyjuice.from.jshint(src.options.jshint);
 } else if (src.options.jscs) {
   output = polyjuice.from.jscs(src.options.jscs);
+} else {
+  output = false;
+  argv.help();
 }
 
-console.log(JSON.stringify(output, null, 2));
+if (output) {
+  console.log(JSON.stringify(output, null, 2));
+}


### PR DESCRIPTION
Currently if you run `$ polyjuice` with no args, it outputs `{}` which isn't super helpful. This should now log the `--help` output if you don't specify a `--jscs` or `--jshint` flag.