### PR TITLE
Remove invalid `always`attribute

### DIFF
--- a/lib/dictionaries/jscs/requireSpaceAfterKeywords.js
+++ b/lib/dictionaries/jscs/requireSpaceAfterKeywords.js
@@ -13,8 +13,5 @@
 
 module.exports = {
     name: 'keyword-spacing',
-    truthy: [
-    2,
-    'always'
-    ]
+    truthy: [ 2 ]
 };


### PR DESCRIPTION
After further review I found that the [Space-After-Keywords](http://eslint.org/docs/rules/space-after-keywords) uses the `always` attribute. However `keyword-spacing` does not. I have removed the invalid attribute in this PR. 